### PR TITLE
Feature/4 migrate to open api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 output/
 *.test
+
+rest-playground.http

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ addons:
       - master
 
 script:
+- EXPORT VERSION=$(shell git describe --tags --match=v* --always --dirty)
 - make ci
+- make sonar
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
       - master
 
 script:
-- EXPORT VERSION=$(shell git describe --tags --match=v* --always --dirty)
 - make ci
 - make sonar
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
 
 script:
 - make ci
-- make sonar
 
 deploy:
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ export CGO_ENABLED:=0
 export GO111MODULE=on
 #export GOFLAGS=-mod=vendor
 
+VERSION=$(shell git describe --tags --match=v* --always --dirty)
+
 .PHONY: all
 all: build test vet lint fmt
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ test_with_report:
 	@echo "+++++++++++  Run GO Test (with report) +++++++++++ "
 	@mkdir -p output
 	@go test ./... -cover -v -coverprofile=output/coverage.out -json > output/unit-test-report.json
+	@echo "Result:"
+	@cat output/unit-test-report.json
 
 .PHONY: vet
 vet:
@@ -39,6 +41,8 @@ vet_with_report:
 	@echo "+++++++++++  Run GO VET (with report) +++++++++++ "
 	@mkdir -p output
 	@go vet -all ./... 2> output/govet-report.out
+	@echo "Result:"
+	@cat output/govet-report.json
 
 .PHONY: lint
 lint:
@@ -50,6 +54,8 @@ lint_with_report:
 	@echo "+++++++++++  Run GO Lint (with report) +++++++++++ "
 	@mkdir -p output
 	@golint -set_exit_status `go list ./...` > output/golint-report.out
+	@echo "Result:"
+	@cat output/golint-report.json
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,6 @@ vet_with_report:
 	@echo "+++++++++++  Run GO VET (with report) +++++++++++ "
 	@mkdir -p output
 	@go vet -all ./... 2> output/govet-report.out
-	@echo "Result:"
-	@cat output/govet-report.json
 
 .PHONY: lint
 lint:
@@ -54,8 +52,6 @@ lint_with_report:
 	@echo "+++++++++++  Run GO Lint (with report) +++++++++++ "
 	@mkdir -p output
 	@golint -set_exit_status `go list ./...` > output/golint-report.out
-	@echo "Result:"
-	@cat output/golint-report.json
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ VERSION=$(shell git describe --tags --match=v* --always --dirty)
 all: build test vet lint fmt
 
 .PHONY: ci
-ci: build test_with_report vet_with_report lint_with_report fmt release
+ci: build test_with_report vet_with_report lint_with_report fmt sonar release
 
 .PHONY: build
 build: clean bin/terraform-provider-instana
@@ -21,13 +21,13 @@ bin/terraform-provider-instana:
 .PHONY: test
 test:
 	@echo "+++++++++++  Run GO Test +++++++++++ "
-	@go test ./... -cover -v
+	@go test ./... -cover
 
 .PHONY: test_with_report
 test_with_report:
 	@echo "+++++++++++  Run GO Test (with report) +++++++++++ "
 	@mkdir -p output
-	@go test ./... -cover -v -coverprofile=output/coverage.out -json > output/unit-test-report.json
+	@go test ./... -cover -coverprofile=output/coverage.out -json > output/unit-test-report.json
 	@echo "Result:"
 	@cat output/unit-test-report.json
 

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,11 @@ export CGO_ENABLED:=0
 export GO111MODULE=on
 #export GOFLAGS=-mod=vendor
 
-VERSION=$(shell git describe --tags --match=v* --always --dirty)
-
 .PHONY: all
 all: build test vet lint fmt
 
 .PHONY: ci
-ci: build test_with_report vet_with_report lint_with_report fmt sonar release
+ci: build test_with_report vet_with_report lint_with_report fmt release
 
 .PHONY: build
 build: clean bin/terraform-provider-instana

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ bin/terraform-provider-instana:
 .PHONY: test
 test:
 	@echo "+++++++++++  Run GO Test +++++++++++ "
-	@go test ./... -cover
+	@go test ./... -cover -v
 
 .PHONY: test_with_report
 test_with_report:
 	@echo "+++++++++++  Run GO Test (with report) +++++++++++ "
 	@mkdir -p output
-	@go test ./... -cover -coverprofile=output/coverage.out -json > output/unit-test-report.json
+	@go test ./... -cover -v -coverprofile=output/coverage.out -json > output/unit-test-report.json
 
 .PHONY: vet
 vet:

--- a/instana/resource-rule-binding_test.go
+++ b/instana/resource-rule-binding_test.go
@@ -41,7 +41,7 @@ resource "instana_rule_binding" "example" {
 }
 `
 
-const ruleBindingApiPath = "/api/ruleBindings/{id}"
+const ruleBindingApiPath = "/api/events/settings/rule-bindings/{id}"
 const testRuleBindingDefinition = "instana_rule_binding.example"
 
 func TestCRUDOfRuleBindingResourceWithMockServer(t *testing.T) {

--- a/instana/resource-rule-binding_test.go
+++ b/instana/resource-rule-binding_test.go
@@ -41,7 +41,7 @@ resource "instana_rule_binding" "example" {
 }
 `
 
-const ruleBindingApiPath = "/api/events/settings/rule-bindings/{id}"
+const ruleBindingApiPath = restapi.RuleBindingsResourcePath + "/{id}"
 const testRuleBindingDefinition = "instana_rule_binding.example"
 
 func TestCRUDOfRuleBindingResourceWithMockServer(t *testing.T) {

--- a/instana/resource-rule-binding_test.go
+++ b/instana/resource-rule-binding_test.go
@@ -3,6 +3,7 @@ package instana_test
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -23,10 +24,10 @@ var testRuleBindingProviders = map[string]terraform.ResourceProvider{
 	"instana": Provider(),
 }
 
-const resourceRuleBindingDefinition = `
+const resourceRuleBindingDefinitionTemplate = `
 provider "instana" {
   api_token = "test-token"
-  endpoint = "localhost:8080"
+  endpoint = "localhost:{{PORT}}"
 }
 
 resource "instana_rule_binding" "example" {
@@ -70,6 +71,8 @@ func TestCRUDOfRuleBindingResourceWithMockServer(t *testing.T) {
 	})
 	httpServer.Start()
 	defer httpServer.Close()
+
+	resourceRuleBindingDefinition := strings.ReplaceAll(resourceRuleBindingDefinitionTemplate, "{{PORT}}", strconv.Itoa(httpServer.GetPort()))
 
 	resource.UnitTest(t, resource.TestCase{
 		Providers: testRuleBindingProviders,

--- a/instana/resource-rule_test.go
+++ b/instana/resource-rule_test.go
@@ -40,7 +40,7 @@ resource "instana_rule" "example" {
 }
 `
 
-const ruleApiPath = "/api/events/settings/rules/{id}"
+const ruleApiPath = restapi.RulesResourcePath + "/{id}"
 const testRuleDefinition = "instana_rule.example"
 
 func TestCRUDOfRuleResourceWithMockServer(t *testing.T) {

--- a/instana/resource-rule_test.go
+++ b/instana/resource-rule_test.go
@@ -40,7 +40,7 @@ resource "instana_rule" "example" {
 }
 `
 
-const ruleApiPath = "/api/rules/{id}"
+const ruleApiPath = "/api/events/settings/rules/{id}"
 const testRuleDefinition = "instana_rule.example"
 
 func TestCRUDOfRuleResourceWithMockServer(t *testing.T) {

--- a/instana/resource-rule_test.go
+++ b/instana/resource-rule_test.go
@@ -3,6 +3,7 @@ package instana_test
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -22,10 +23,10 @@ var testRuleProviders = map[string]terraform.ResourceProvider{
 	"instana": Provider(),
 }
 
-const resourceRuleDefinition = `
+const resourceRuleDefinitionTemplate = `
 provider "instana" {
   api_token = "test-token"
-  endpoint = "localhost:8080"
+  endpoint = "localhost:{{PORT}}"
 }
 
 resource "instana_rule" "example" {
@@ -69,6 +70,8 @@ func TestCRUDOfRuleResourceWithMockServer(t *testing.T) {
 	})
 	httpServer.Start()
 	defer httpServer.Close()
+
+	resourceRuleDefinition := strings.ReplaceAll(resourceRuleDefinitionTemplate, "{{PORT}}", strconv.Itoa(httpServer.GetPort()))
 
 	resource.UnitTest(t, resource.TestCase{
 		Providers: testRuleProviders,

--- a/instana/restapi/api.go
+++ b/instana/restapi/api.go
@@ -2,6 +2,21 @@ package restapi
 
 import "errors"
 
+//InstanaAPIBasePath path to Instana RESTful API
+const InstanaAPIBasePath = "/api"
+
+//EventsBasePath path to Events resource of Instana RESTful API
+const EventsBasePath = InstanaAPIBasePath + "/events"
+
+//EventSettingsBasePath path to Event Settings resource of Instana RESTful API
+const EventSettingsBasePath = EventsBasePath + "/settings"
+
+//RulesResourcePath path to Rule resource of Instana RESTful API
+const RulesResourcePath = EventSettingsBasePath + "/rules"
+
+//RuleBindingsResourcePath path to Rule Binding resource of Instana RESTful API
+const RuleBindingsResourcePath = EventSettingsBasePath + "/rule-bindings"
+
 //InstanaDataObject is a marker interface for any data object provided by any resource of the Instana REST API
 type InstanaDataObject interface {
 	GetID() string

--- a/instana/restapi/resources/rule-bindings.go
+++ b/instana/restapi/resources/rule-bindings.go
@@ -11,7 +11,7 @@ import (
 func NewRuleBindingResource(client restapi.RestClient) restapi.RuleBindingResource {
 	return &RuleBindingResourceImpl{
 		client:       client,
-		resourcePath: "/events/settings/rule-bindings",
+		resourcePath: restapi.RuleBindingsResourcePath,
 	}
 }
 

--- a/instana/restapi/resources/rule-bindings.go
+++ b/instana/restapi/resources/rule-bindings.go
@@ -11,7 +11,7 @@ import (
 func NewRuleBindingResource(client restapi.RestClient) restapi.RuleBindingResource {
 	return &RuleBindingResourceImpl{
 		client:       client,
-		resourcePath: "/ruleBindings",
+		resourcePath: "/events/settings/rule-bindings",
 	}
 }
 

--- a/instana/restapi/resources/rule-bindings_test.go
+++ b/instana/restapi/resources/rule-bindings_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-const bindingRulePath = "/events/settings/rule-bindings"
-
 func TestSuccessfulGetOneRuleBinding(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -24,7 +22,7 @@ func TestSuccessfulGetOneRuleBinding(t *testing.T) {
 	ruleBinding := makeTestRuleBinding()
 	serializedJSON, _ := json.Marshal(ruleBinding)
 
-	client.EXPECT().GetOne(gomock.Eq(ruleBinding.ID), gomock.Eq(bindingRulePath)).Return(serializedJSON, nil)
+	client.EXPECT().GetOne(gomock.Eq(ruleBinding.ID), gomock.Eq(restapi.RuleBindingsResourcePath)).Return(serializedJSON, nil)
 
 	data, err := sut.GetOne(ruleBinding.ID)
 
@@ -45,7 +43,7 @@ func TestFailedGetOneRuleBindingBecauseOfErrorFromRestClient(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBindingID := "test-rule-binding-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(bindingRulePath)).Return(nil, errors.New("error during test"))
+	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(restapi.RuleBindingsResourcePath)).Return(nil, errors.New("error during test"))
 
 	_, err := sut.GetOne(ruleBindingID)
 
@@ -62,7 +60,7 @@ func TestFailedGetOneRuleBindingBecauseOfInvalidJsonArray(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBindingID := "test-rule-binding-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(bindingRulePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
+	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
 
 	_, err := sut.GetOne(ruleBindingID)
 
@@ -79,7 +77,7 @@ func TestFailedGetOneRuleBindingBecauseOfInvalidJsonObject(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBindingID := "test-rule-binding-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(bindingRulePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
+	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
 
 	_, err := sut.GetOne(ruleBindingID)
 
@@ -96,7 +94,7 @@ func TestFailedGetOneRuleBindingBecauseOfNoJsonAsResponse(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBindingID := "test-rule-binding-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(bindingRulePath)).Return([]byte("Invalid Data"), nil)
+	client.EXPECT().GetOne(gomock.Eq(ruleBindingID), gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("Invalid Data"), nil)
 
 	_, err := sut.GetOne(ruleBindingID)
 
@@ -116,7 +114,7 @@ func TestSuccessfulGetAllRuleBindings(t *testing.T) {
 	ruleBindings := []restapi.RuleBinding{ruleBinding1, ruleBinding2}
 	serializedJSON, _ := json.Marshal(ruleBindings)
 
-	client.EXPECT().GetAll(gomock.Eq(bindingRulePath)).Return(serializedJSON, nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RuleBindingsResourcePath)).Return(serializedJSON, nil)
 
 	data, err := sut.GetAll()
 
@@ -136,7 +134,7 @@ func TestFailedGetAllRuleBindingsWithErrorFromRestClient(t *testing.T) {
 	client := mocks.NewMockRestClient(ctrl)
 	sut := NewRuleBindingResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(bindingRulePath)).Return(nil, errors.New("error during test"))
+	client.EXPECT().GetAll(gomock.Eq(restapi.RuleBindingsResourcePath)).Return(nil, errors.New("error during test"))
 
 	_, err := sut.GetAll()
 
@@ -152,7 +150,7 @@ func TestFailedGetAllRuleBindingsWithInvalidJsonArray(t *testing.T) {
 	client := mocks.NewMockRestClient(ctrl)
 	sut := NewRuleBindingResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(bindingRulePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
 
 	_, err := sut.GetAll()
 
@@ -168,7 +166,7 @@ func TestFailedGetAllRuleBindingWithInvalidJsonObject(t *testing.T) {
 	client := mocks.NewMockRestClient(ctrl)
 	sut := NewRuleBindingResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(bindingRulePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
 
 	_, err := sut.GetAll()
 
@@ -184,7 +182,7 @@ func TestFailedGetAllRuleBindingsWithNoJsonAsResponse(t *testing.T) {
 	client := mocks.NewMockRestClient(ctrl)
 	sut := NewRuleBindingResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(bindingRulePath)).Return([]byte("Invalid Data"), nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("Invalid Data"), nil)
 
 	_, err := sut.GetAll()
 
@@ -202,7 +200,7 @@ func TestSuccessfulUpsertOfRuleBinding(t *testing.T) {
 	ruleBinding := makeTestRuleBinding()
 	serializedJSON, _ := json.Marshal(ruleBinding)
 
-	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(bindingRulePath)).Return(serializedJSON, nil)
+	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(restapi.RuleBindingsResourcePath)).Return(serializedJSON, nil)
 
 	result, err := sut.Upsert(ruleBinding)
 
@@ -232,7 +230,7 @@ func TestFailedUpsertOfRuleBindingBecauseOfInvalidRuleBinding(t *testing.T) {
 		RuleIds:        []string{"test-rule-id"},
 	}
 
-	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(bindingRulePath)).Times(0)
+	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(restapi.RuleBindingsResourcePath)).Times(0)
 
 	_, err := sut.Upsert(ruleBinding)
 
@@ -249,7 +247,7 @@ func TestFailedUpsertOfRuleBindingBecauseOfInvalidResponseMessage(t *testing.T) 
 	sut := NewRuleBindingResource(client)
 	ruleBinding := makeTestRuleBinding()
 
-	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(bindingRulePath)).Return([]byte("invalid response"), nil)
+	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("invalid response"), nil)
 
 	_, err := sut.Upsert(ruleBinding)
 
@@ -266,7 +264,7 @@ func TestFailedUpsertOfRuleBindingBecauseOfInvalidRuleInResponse(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBinding := makeTestRuleBinding()
 
-	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(bindingRulePath)).Return([]byte("{ \"invalid\" : \"rule\" }"), nil)
+	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(restapi.RuleBindingsResourcePath)).Return([]byte("{ \"invalid\" : \"rule\" }"), nil)
 
 	_, err := sut.Upsert(ruleBinding)
 
@@ -283,7 +281,7 @@ func TestFailedUpsertOfRuleBindingBecauseOfClientError(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBinding := makeTestRuleBinding()
 
-	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(bindingRulePath)).Return(nil, errors.New("Error during test"))
+	client.EXPECT().Put(gomock.Eq(ruleBinding), gomock.Eq(restapi.RuleBindingsResourcePath)).Return(nil, errors.New("Error during test"))
 
 	_, err := sut.Upsert(ruleBinding)
 
@@ -300,7 +298,7 @@ func TestSuccessfulDeleteOfRuleBindingByRuleBinding(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBinding := makeTestRuleBinding()
 
-	client.EXPECT().Delete(gomock.Eq("test-rule-binding-id-1"), gomock.Eq(bindingRulePath)).Return(nil)
+	client.EXPECT().Delete(gomock.Eq("test-rule-binding-id-1"), gomock.Eq(restapi.RuleBindingsResourcePath)).Return(nil)
 
 	err := sut.Delete(ruleBinding)
 
@@ -317,7 +315,7 @@ func TestFailedDeleteOfRuleBindingByRuleBinding(t *testing.T) {
 	sut := NewRuleBindingResource(client)
 	ruleBinding := makeTestRuleBinding()
 
-	client.EXPECT().Delete(gomock.Eq("test-rule-binding-id-1"), gomock.Eq(bindingRulePath)).Return(errors.New("Error during test"))
+	client.EXPECT().Delete(gomock.Eq("test-rule-binding-id-1"), gomock.Eq(restapi.RuleBindingsResourcePath)).Return(errors.New("Error during test"))
 
 	err := sut.Delete(ruleBinding)
 

--- a/instana/restapi/resources/rule-bindings_test.go
+++ b/instana/restapi/resources/rule-bindings_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-const bindingRulePath = "/ruleBindings"
+const bindingRulePath = "/events/settings/rule-bindings"
 
 func TestSuccessfulGetOneRuleBinding(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/instana/restapi/resources/rules.go
+++ b/instana/restapi/resources/rules.go
@@ -11,7 +11,7 @@ import (
 func NewRuleResource(client restapi.RestClient) restapi.RuleResource {
 	return &RuleResourceImpl{
 		client:       client,
-		resourcePath: "/rules",
+		resourcePath: "/events/settings/rules",
 	}
 }
 

--- a/instana/restapi/resources/rules.go
+++ b/instana/restapi/resources/rules.go
@@ -11,7 +11,7 @@ import (
 func NewRuleResource(client restapi.RestClient) restapi.RuleResource {
 	return &RuleResourceImpl{
 		client:       client,
-		resourcePath: "/events/settings/rules",
+		resourcePath: restapi.RulesResourcePath,
 	}
 }
 

--- a/instana/restapi/resources/rules_test.go
+++ b/instana/restapi/resources/rules_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-const rulePath = "/rules"
+const rulePath = "/events/settings/rules"
 
 func TestSuccessfulGetOneRule(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/instana/restapi/resources/rules_test.go
+++ b/instana/restapi/resources/rules_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-const rulePath = "/events/settings/rules"
-
 func TestSuccessfulGetOneRule(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -24,7 +22,7 @@ func TestSuccessfulGetOneRule(t *testing.T) {
 	rule := makeTestRule()
 	serializedJSON, _ := json.Marshal(rule)
 
-	client.EXPECT().GetOne(gomock.Eq(rule.ID), gomock.Eq(rulePath)).Return(serializedJSON, nil)
+	client.EXPECT().GetOne(gomock.Eq(rule.ID), gomock.Eq(restapi.RulesResourcePath)).Return(serializedJSON, nil)
 
 	data, err := sut.GetOne(rule.ID)
 
@@ -45,7 +43,7 @@ func TestFailedGetOneRuleBecauseOfErrorFromRestClient(t *testing.T) {
 	sut := NewRuleResource(client)
 	ruleID := "test-rule-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(rulePath)).Return(nil, errors.New("error during test"))
+	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(restapi.RulesResourcePath)).Return(nil, errors.New("error during test"))
 
 	_, err := sut.GetOne(ruleID)
 
@@ -62,7 +60,7 @@ func TestFailedGetOneRuleBecauseOfInvalidJsonArray(t *testing.T) {
 	sut := NewRuleResource(client)
 	ruleID := "test-rule-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(rulePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
+	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(restapi.RulesResourcePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
 
 	_, err := sut.GetOne(ruleID)
 
@@ -79,7 +77,7 @@ func TestFailedGetOneRuleBecauseOfInvalidJsonObject(t *testing.T) {
 	sut := NewRuleResource(client)
 	ruleID := "test-rule-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(rulePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
+	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(restapi.RulesResourcePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
 
 	_, err := sut.GetOne(ruleID)
 
@@ -96,7 +94,7 @@ func TestFailedGetOneRuleBecauseOfNoJsonAsResponse(t *testing.T) {
 	sut := NewRuleResource(client)
 	ruleID := "test-rule-id"
 
-	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(rulePath)).Return([]byte("Invalid Data"), nil)
+	client.EXPECT().GetOne(gomock.Eq(ruleID), gomock.Eq(restapi.RulesResourcePath)).Return([]byte("Invalid Data"), nil)
 
 	_, err := sut.GetOne(ruleID)
 
@@ -116,7 +114,7 @@ func TestSuccessfulGetAllRules(t *testing.T) {
 	rules := []restapi.Rule{rule1, rule2}
 	serializedJSON, _ := json.Marshal(rules)
 
-	client.EXPECT().GetAll(gomock.Eq(rulePath)).Return(serializedJSON, nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RulesResourcePath)).Return(serializedJSON, nil)
 
 	data, err := sut.GetAll()
 
@@ -136,7 +134,7 @@ func TestFailedGetAllRulesWithErrorFromRestClient(t *testing.T) {
 
 	sut := NewRuleResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(rulePath)).Return(nil, errors.New("error during test"))
+	client.EXPECT().GetAll(gomock.Eq(restapi.RulesResourcePath)).Return(nil, errors.New("error during test"))
 
 	_, err := sut.GetAll()
 
@@ -152,7 +150,7 @@ func TestFailedGetAllRulesWithInvalidJsonArray(t *testing.T) {
 
 	sut := NewRuleResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(rulePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RulesResourcePath)).Return([]byte("[{ \"invalid\" : \"data\" }]"), nil)
 
 	_, err := sut.GetAll()
 
@@ -168,7 +166,7 @@ func TestFailedGetAllRulesWithInvalidJsonObject(t *testing.T) {
 
 	sut := NewRuleResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(rulePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RulesResourcePath)).Return([]byte("{ \"invalid\" : \"data\" }"), nil)
 
 	_, err := sut.GetAll()
 
@@ -184,7 +182,7 @@ func TestFailedGetAllRulesWithNoJsonAsResponse(t *testing.T) {
 
 	sut := NewRuleResource(client)
 
-	client.EXPECT().GetAll(gomock.Eq(rulePath)).Return([]byte("Invalid Data"), nil)
+	client.EXPECT().GetAll(gomock.Eq(restapi.RulesResourcePath)).Return([]byte("Invalid Data"), nil)
 
 	_, err := sut.GetAll()
 
@@ -202,7 +200,7 @@ func TestSuccessfulUpsertOfRule(t *testing.T) {
 	rule := makeTestRule()
 	serializedJSON, _ := json.Marshal(rule)
 
-	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(rulePath)).Return(serializedJSON, nil)
+	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(restapi.RulesResourcePath)).Return(serializedJSON, nil)
 
 	result, err := sut.Upsert(rule)
 
@@ -223,7 +221,7 @@ func TestFailedUpsertOfRuleBecauseOfClientError(t *testing.T) {
 	sut := NewRuleResource(client)
 	rule := makeTestRule()
 
-	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(rulePath)).Return(nil, errors.New("Error during test"))
+	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(restapi.RulesResourcePath)).Return(nil, errors.New("Error during test"))
 
 	_, err := sut.Upsert(rule)
 
@@ -240,7 +238,7 @@ func TestFailedUpsertOfRuleBecauseOfInvalidResponseMessage(t *testing.T) {
 	sut := NewRuleResource(client)
 	rule := makeTestRule()
 
-	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(rulePath)).Return([]byte("invalid response"), nil)
+	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(restapi.RulesResourcePath)).Return([]byte("invalid response"), nil)
 
 	_, err := sut.Upsert(rule)
 
@@ -257,7 +255,7 @@ func TestFailedUpsertOfRuleBecauseOfInvalidRuleInResponse(t *testing.T) {
 	sut := NewRuleResource(client)
 	rule := makeTestRule()
 
-	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(rulePath)).Return([]byte("{ \"invalid\" : \"rule\" }"), nil)
+	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(restapi.RulesResourcePath)).Return([]byte("{ \"invalid\" : \"rule\" }"), nil)
 
 	_, err := sut.Upsert(rule)
 
@@ -283,7 +281,7 @@ func TestFailedUpsertOfRuleBecauseOfInvalidRuleProvided(t *testing.T) {
 		ConditionOperator: ">",
 	}
 
-	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(rulePath)).Times(0)
+	client.EXPECT().Put(gomock.Eq(rule), gomock.Eq(restapi.RulesResourcePath)).Times(0)
 
 	_, err := sut.Upsert(rule)
 
@@ -300,7 +298,7 @@ func TestSuccessfulDeleteOfRuleByRule(t *testing.T) {
 	sut := NewRuleResource(client)
 	rule := makeTestRule()
 
-	client.EXPECT().Delete(gomock.Eq("test-rule-id-1"), gomock.Eq(rulePath)).Return(nil)
+	client.EXPECT().Delete(gomock.Eq("test-rule-id-1"), gomock.Eq(restapi.RulesResourcePath)).Return(nil)
 
 	err := sut.Delete(rule)
 
@@ -317,7 +315,7 @@ func TestFailedDeleteOfRuleByRule(t *testing.T) {
 	sut := NewRuleResource(client)
 	rule := makeTestRule()
 
-	client.EXPECT().Delete(gomock.Eq("test-rule-id-1"), gomock.Eq(rulePath)).Return(errors.New("Error during test"))
+	client.EXPECT().Delete(gomock.Eq("test-rule-id-1"), gomock.Eq(restapi.RulesResourcePath)).Return(errors.New("Error during test"))
 
 	err := sut.Delete(rule)
 

--- a/instana/restapi/services/rest-client.go
+++ b/instana/restapi/services/rest-client.go
@@ -100,9 +100,5 @@ func (client *RestClientImpl) buildResourceURL(resourceBasePath string, id strin
 }
 
 func (client *RestClientImpl) buildURL(resourcePath string) string {
-	apiPath := "api"
-	if !strings.HasPrefix(resourcePath, "/") {
-		apiPath = apiPath + "/"
-	}
-	return fmt.Sprintf("https://%s/%s%s", client.host, apiPath, resourcePath)
+	return fmt.Sprintf("https://%s%s", client.host, resourcePath)
 }

--- a/instana/restapi/services/rest-client_test.go
+++ b/instana/restapi/services/rest-client_test.go
@@ -15,11 +15,10 @@ import (
 const testPath = "/test"
 const testID = "test-1234"
 const testData = "testData"
-const fullPathWithoutID = "/api" + testPath
-const fullPathWithID = "/api" + testPath + "/" + testID
+const testPathWithID = testPath + "/" + testID
 
 func TestShouldReturnDataForSuccessfulGetOneRequest(t *testing.T) {
-	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodGet, fullPathWithID)
+	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodGet, testPathWithID)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -30,7 +29,7 @@ func TestShouldReturnDataForSuccessfulGetOneRequest(t *testing.T) {
 
 func TestShouldReturnErrorMessageForGetOneRequestWhenStatusIsNotASuccessStatusAndNotEnityNotFound(t *testing.T) {
 	statusCode := http.StatusBadRequest
-	httpServer := setupAndStartHttpServer(http.MethodGet, fullPathWithID, statusCode)
+	httpServer := setupAndStartHttpServer(http.MethodGet, testPathWithID, statusCode)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -40,7 +39,7 @@ func TestShouldReturnErrorMessageForGetOneRequestWhenStatusIsNotASuccessStatusAn
 }
 
 func TestShouldReturnNotFoundErrorMessageForGetOneRequestWhenStatusIsNotEnityNotFound(t *testing.T) {
-	httpServer := setupAndStartHttpServer(http.MethodGet, fullPathWithID, http.StatusNotFound)
+	httpServer := setupAndStartHttpServer(http.MethodGet, testPathWithID, http.StatusNotFound)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -50,7 +49,7 @@ func TestShouldReturnNotFoundErrorMessageForGetOneRequestWhenStatusIsNotEnityNot
 }
 
 func TestShouldReturnDataForSuccessfulGetAllRequest(t *testing.T) {
-	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodGet, fullPathWithoutID)
+	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodGet, testPath)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -61,7 +60,7 @@ func TestShouldReturnDataForSuccessfulGetAllRequest(t *testing.T) {
 
 func TestShouldReturnErrorMessageForGetAllRequestWhenStatusIsNotASuccessStatusAndNotEnityNotFound(t *testing.T) {
 	statusCode := http.StatusBadRequest
-	httpServer := setupAndStartHttpServer(http.MethodGet, fullPathWithoutID, statusCode)
+	httpServer := setupAndStartHttpServer(http.MethodGet, testPath, statusCode)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -71,7 +70,7 @@ func TestShouldReturnErrorMessageForGetAllRequestWhenStatusIsNotASuccessStatusAn
 }
 
 func TestShouldReturnNotFoundErrorMessageForGetAllRequestWhenStatusIsNotEnityNotFound(t *testing.T) {
-	httpServer := setupAndStartHttpServer(http.MethodGet, fullPathWithoutID, http.StatusNotFound)
+	httpServer := setupAndStartHttpServer(http.MethodGet, testPath, http.StatusNotFound)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -81,7 +80,7 @@ func TestShouldReturnNotFoundErrorMessageForGetAllRequestWhenStatusIsNotEnityNot
 }
 
 func TestShouldReturnDataForSuccessfulPutRequest(t *testing.T) {
-	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodPut, fullPathWithID)
+	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodPut, testPathWithID)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -92,7 +91,7 @@ func TestShouldReturnDataForSuccessfulPutRequest(t *testing.T) {
 
 func TestShouldReturnErrorMessageForPutRequestWhenStatusIsNotASuccessStatusAndNotEnityNotFound(t *testing.T) {
 	statusCode := http.StatusBadRequest
-	httpServer := setupAndStartHttpServer(http.MethodPut, fullPathWithID, statusCode)
+	httpServer := setupAndStartHttpServer(http.MethodPut, testPathWithID, statusCode)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -117,7 +116,7 @@ func (tdo testDataObject) Validate() error {
 
 func TestShouldReturnNothingForSuccessfulDeleteRequest(t *testing.T) {
 	testutils.DeactivateTLSServerCertificateVerification()
-	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodDelete, fullPathWithID)
+	httpServer := setupAndStartHttpServerWithOKResponseCode(http.MethodDelete, testPathWithID)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)
@@ -130,7 +129,7 @@ func TestShouldReturnNothingForSuccessfulDeleteRequest(t *testing.T) {
 
 func TestShouldReturnErrorMessageForDeleteRequestWhenStatusIsNotASuccessStatusAndNotEnityNotFound(t *testing.T) {
 	statusCode := http.StatusBadRequest
-	httpServer := setupAndStartHttpServer(http.MethodDelete, fullPathWithID, statusCode)
+	httpServer := setupAndStartHttpServer(http.MethodDelete, testPathWithID, statusCode)
 	defer httpServer.Close()
 
 	restClient := createSut(httpServer)

--- a/test-utils/test-http-server_test.go
+++ b/test-utils/test-http-server_test.go
@@ -39,3 +39,11 @@ func TestShouldStartNewInstanceWithDynamicPortAndStopTheServerOnClose(t *testing
 		t.Fatalf("Expected to get '%s' but got '%s'", testString, responseString)
 	}
 }
+
+func TestShouldCreateRandomPortNumber(t *testing.T) {
+	result := testutils.RandomPort()
+
+	if result < testutils.MinPortNumber || result > testutils.MaxPortNumber {
+		t.Fatalf("Expected port number between %d and %d but got %d", testutils.MinPortNumber, testutils.MaxPortNumber, result)
+	}
+}


### PR DESCRIPTION
#4 fixed with changing the paths to the new endpoints. The data models are still the same.