### PR TITLE
#22: migrate to customizable default name prefix and suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ two configuration options needed to setup the Instana Terraform Provider:
 
 - api_token: The API token which is created in the Settings area of Instana for remote access through the REST API. You have to make sure that you assign the proper permissions for this token to configure the desired resources with this provider. E.g. when User Roles should be provisioned by terraform using this provider implementation then the permission 'Access role configuration' must be activated
 - endpoint: The endpoint of the instana backend. For SaaS the endpoint URL has the pattern _tenant_-_organization_.instana.io. For onPremise installation the endpoint URL depends on your local setup.
-- add_terraform_managed_string: optional - default true - boolean flag if the string ' (TF managed)' should be appended to the resource UI name or label (not supported by all resources). For existing resources the string will only be appended when the name/label is changed.
+- default_name_prefix: optional - default "" - string which should be added in front the resource UI name or label by default (not supported by all resources). For existing resources the string will only be added when the name/label is changed.
+- default_name_suffix: optional - default " (TF managed)" - string which should be appended to the resource UI name or label by default (not supported by all resources). For existing resources the string will only be appended when the name/label is changed.
 
 ```hcl
 provider "instana" {
   api_token = "secure-api-token"  
   endpoint = "<tenant>-<org>.instana.io"
-  add_terraform_managed_string = true
+  default_name_prefix = ""
+  default_name_suffix = "(TF managed)"
 }
 ```
 
@@ -63,7 +65,7 @@ Management of application configurations (definition of application perspectives
 API Documentation: <https://instana.github.io/openapi/#operation/putApplicationConfig>
 
 The ID of the resource which is also used as unique identifier in Instana is auto generated!
-The resource supports `add_terraform_managed_string` and will append the string automatically
+The resource supports `default_name_prefix` and `default_name_suffix` and will append the string automatically
 to the application config label when active.
 
 ```hcl
@@ -118,7 +120,7 @@ Custom Event Specification support two different flavors:
 - System Rules - defines an event triggered by a system rule
 - Threshold Rules - defines an event triggered by a rule for a certain metric comparing the value with a given value over a time window
 
-Custom event resources supports `add_terraform_managed_string`. The string will be appended automatically
+Custom event resources supports `default_name_prefix` and `default_name_suffix`. The string will be appended automatically
 to the name of the custom event.
 
 ###### Custom Event Specification with System Rules
@@ -194,7 +196,7 @@ Management of user roles.
 API Documentation: <https://instana.github.io/openapi/#operation/getRole>
 
 The ID of the resource which is also used as unique identifier in Instana is auto generated!
-The resource does NOT support `add_terraform_managed_string`.
+The resource does NOT support `default_name_prefix` and `default_name_suffix`.
 
 ```hcl
 resource "instana_user_role" "example" {

--- a/instana/provider.go
+++ b/instana/provider.go
@@ -12,8 +12,11 @@ const SchemaFieldAPIToken = "api_token"
 //SchemaFieldEndpoint the name of the provider configuration option for the instana endpoint
 const SchemaFieldEndpoint = "endpoint"
 
-//SchemaFieldAddTerraformManagedString the indicator if a string should be appended to a name or description that the resource is managed by terraform
-const SchemaFieldAddTerraformManagedString = "add_terraform_managed_string"
+//SchemaFieldDefaultNamePrefix the default prefix which should be added to all resource names/labels
+const SchemaFieldDefaultNamePrefix = "default_name_prefix"
+
+//SchemaFieldDefaultNameSuffix the default prefix which should be added to all resource names/labels
+const SchemaFieldDefaultNameSuffix = "default_name_suffix"
 
 //ResourceInstanaRule the name of the terraform-provider-instana resource to manage rules
 const ResourceInstanaRule = "instana_rule"
@@ -60,11 +63,17 @@ func providerSchema() map[string]*schema.Schema {
 			Required:    true,
 			Description: "The DNS Name of the Instana Endpoint (eg. saas-eu-west-1.instana.io)",
 		},
-		SchemaFieldAddTerraformManagedString: &schema.Schema{
-			Type:        schema.TypeBool,
+		SchemaFieldDefaultNamePrefix: &schema.Schema{
+			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     true,
-			Description: "The indicator if a string should be appended to a name or description that the resource is managed by terraform",
+			Default:     "",
+			Description: "The default prefix which should be added to all resource names/labels",
+		},
+		SchemaFieldDefaultNameSuffix: &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "(TF managed)",
+			Description: "The default suffix which should be added to all resource names/labels - default '(TF managed)'",
 		},
 	}
 }
@@ -81,9 +90,10 @@ func providerResources() map[string]*schema.Resource {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	apiToken := d.Get(SchemaFieldAPIToken).(string)
 	endpoint := d.Get(SchemaFieldEndpoint).(string)
-	appendTerraformManagedString := d.Get(SchemaFieldAddTerraformManagedString).(bool)
+	defaultNamePrefix := d.Get(SchemaFieldDefaultNamePrefix).(string)
+	defaultNameSuffix := d.Get(SchemaFieldDefaultNameSuffix).(string)
 	instanaAPI := services.NewInstanaAPI(apiToken, endpoint)
-	formatter := NewResourceNameFormatter(appendTerraformManagedString)
+	formatter := NewResourceNameFormatter(defaultNamePrefix, defaultNameSuffix)
 	return &ProviderMeta{
 		InstanaAPI:            instanaAPI,
 		ResourceNameFormatter: formatter,

--- a/instana/provider_test.go
+++ b/instana/provider_test.go
@@ -33,13 +33,14 @@ func TestValidConfigurationOfProvider(t *testing.T) {
 }
 
 func validateSchema(schemaMap map[string]*schema.Schema, t *testing.T) {
-	if len(schemaMap) != 3 {
+	if len(schemaMap) != 4 {
 		t.Fatal("Expected three configuration options for provider")
 	}
 	schemaAssert := testutils.NewTerraformSchemaAssert(schemaMap, t)
 	schemaAssert.AssertSchemaIsRequiredAndOfTypeString(SchemaFieldAPIToken)
 	schemaAssert.AssertSchemaIsRequiredAndOfTypeString(SchemaFieldEndpoint)
-	schemaAssert.AssertSchemaIsOfTypeBooleanWithDefault(SchemaFieldAddTerraformManagedString, true)
+	schemaAssert.AssertSchemaIsOptionalAndOfTypeStringWithDefault(SchemaFieldDefaultNamePrefix, "")
+	schemaAssert.AssertSchemaIsOptionalAndOfTypeStringWithDefault(SchemaFieldDefaultNameSuffix, "(TF managed)")
 }
 
 func validateResourcesMap(resourceMap map[string]*schema.Resource, t *testing.T) {

--- a/instana/resource-application-config.go
+++ b/instana/resource-application-config.go
@@ -30,7 +30,7 @@ const (
 const (
 	//ApplicationConfigFieldLabel const for the label field of the application config
 	ApplicationConfigFieldLabel = "label"
-	//ApplicationConfigFieldFullLabel const for the full label field of the application config. The field is computed and contains the label which is sent to instana. The computation depends on the activation of add_terraform_managed_string at provider level
+	//ApplicationConfigFieldFullLabel const for the full label field of the application config. The field is computed and contains the label which is sent to instana. The computation depends on the configured default_name_prefix and default_name_suffix at provider level
 	ApplicationConfigFieldFullLabel = "full_label"
 	//ApplicationConfigFieldScope const for the scope field of the application config
 	ApplicationConfigFieldScope = "scope"
@@ -55,7 +55,7 @@ func CreateResourceApplicationConfig() *schema.Resource {
 			ApplicationConfigFieldFullLabel: &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The the full label field of the application config. The field is computed and contains the label which is sent to instana. The computation depends on the activation of add_terraform_managed_string at provider level",
+				Description: "The the full label field of the application config. The field is computed and contains the label which is sent to instana. The computation depends on the configured default_name_prefix and default_name_suffix at provider level",
 			},
 			ApplicationConfigFieldScope: &schema.Schema{
 				Type:         schema.TypeString,

--- a/instana/resource-application-config_test.go
+++ b/instana/resource-application-config_test.go
@@ -28,6 +28,8 @@ const resourceApplicationConfigDefinitionTemplate = `
 provider "instana" {
   api_token = "test-token"
   endpoint = "localhost:{{PORT}}"
+  default_name_prefix = "prefix"
+  default_name_suffix = "suffix"
 }
 
 resource "instana_application_config" "example" {
@@ -40,7 +42,7 @@ resource "instana_application_config" "example" {
 const serverResponseTemplate = `
 {
 	"id" : "{{id}}",
-	"label" : "label (TF managed)",
+	"label" : "prefix label suffix",
 	"scope" : "INCLUDE_ALL_DOWNSTREAM",
 	"matchSpecification" : {
 		"type" : "BINARY_OP",
@@ -108,7 +110,7 @@ func TestCRUDOfApplicationConfigResourceWithMockServer(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(testApplicationConfigDefinition, "id"),
 					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldLabel, "label 0"),
-					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldFullLabel, "label 0 (TF managed)"),
+					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldFullLabel, "prefix label 0 suffix"),
 					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldScope, "INCLUDE_ALL_DOWNSTREAM"),
 					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldMatchSpecification, defaultMatchSpecification),
 				),
@@ -118,7 +120,7 @@ func TestCRUDOfApplicationConfigResourceWithMockServer(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(testApplicationConfigDefinition, "id"),
 					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldLabel, "label 1"),
-					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldFullLabel, "label 1 (TF managed)"),
+					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldFullLabel, "prefix label 1 suffix"),
 					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldScope, "INCLUDE_ALL_DOWNSTREAM"),
 					resource.TestCheckResourceAttr(testApplicationConfigDefinition, ApplicationConfigFieldMatchSpecification, defaultMatchSpecification),
 				),

--- a/instana/resource-custom-event-specficiation-threshold-rule_test.go
+++ b/instana/resource-custom-event-specficiation-threshold-rule_test.go
@@ -28,6 +28,8 @@ const resourceCustomEventSpecificationWithThresholdRuleAndRollupDefinitionTempla
 provider "instana" {
   api_token = "test-token"
   endpoint = "localhost:{{PORT}}"
+  default_name_prefix = "prefix"
+  default_name_suffix = "suffix"
 }
 
 resource "instana_custom_event_spec_threshold_rule" "example" {
@@ -52,6 +54,8 @@ const resourceCustomEventSpecificationWithThresholdRuleAndWindowDefinitionTempla
 provider "instana" {
   api_token = "test-token"
   endpoint = "localhost:{{PORT}}"
+  default_name_prefix = "prefix"
+  default_name_suffix = "suffix"
 }
 
 resource "instana_custom_event_spec_threshold_rule" "example" {
@@ -125,7 +129,7 @@ func TestCRUDOfCustomEventSpecificationWithThresholdRuleWithWindowResourceWithMo
 const httpServerResponseTemplate = `
 {
 	"id" : "{{id}}",
-	"name" : "name (TF managed)",
+	"name" : "prefix name suffix",
 	"entityType" : "entity_type",
 	"query" : "query",
 	"enabled" : true,
@@ -179,7 +183,7 @@ func createTestCheckFunctions(ruleTestCheckFunctions []resource.TestCheckFunc, i
 	defaultCheckFunctions := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(testCustomEventSpecificationWithThresholdRuleDefinition, "id"),
 		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, CustomEventSpecificationFieldName, customEventSpecificationWithThresholdRuleName+fmt.Sprintf(" %d", iteration)),
-		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, CustomEventSpecificationFieldFullName, customEventSpecificationWithThresholdRuleName+fmt.Sprintf(" %d%s", iteration, TerraformManagedResourceNameSuffix)),
+		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, CustomEventSpecificationFieldFullName, fmt.Sprintf("%s %s %d %s", "prefix", customEventSpecificationWithThresholdRuleName, iteration, "suffix")),
 		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, CustomEventSpecificationFieldEntityType, customEventSpecificationWithThresholdRuleEntityType),
 		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, CustomEventSpecificationFieldQuery, customEventSpecificationWithThresholdRuleQuery),
 		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, CustomEventSpecificationFieldTriggering, "true"),

--- a/instana/resource-custom-event-specification-common.go
+++ b/instana/resource-custom-event-specification-common.go
@@ -14,7 +14,7 @@ import (
 const (
 	//CustomEventSpecificationFieldName constant value for the schema field name
 	CustomEventSpecificationFieldName = "name"
-	//CustomEventSpecificationFieldFullName constant value for the schema field full_name. The field is computed and contains the name which is sent to instana. The computation depends on the activation of add_terraform_managed_string at provider level
+	//CustomEventSpecificationFieldFullName constant value for the schema field full_name. The field is computed and contains the name which is sent to instana. The computation depends on the configured default_name_prefix and default_name_suffix at provider level
 	CustomEventSpecificationFieldFullName = "full_name"
 	//CustomEventSpecificationFieldEntityType constant value for the schema field entity type
 	CustomEventSpecificationFieldEntityType = "entity_type"
@@ -52,7 +52,7 @@ func createCustomEventSpecificationSchema(ruleSpecificSchemaFields map[string]*s
 		CustomEventSpecificationFieldFullName: &schema.Schema{
 			Type:        schema.TypeString,
 			Computed:    true,
-			Description: "The computed full name of the custom event specification. The field contains the name which is sent to instana. The computation depends on the activation of add_terraform_managed_string at provider level",
+			Description: "The computed full name of the custom event specification. The field contains the name which is sent to instana. The computation depends on the configured default_name_prefix and default_name_suffix at provider level",
 		},
 		CustomEventSpecificationFieldEntityType: &schema.Schema{
 			Type:        schema.TypeString,

--- a/instana/resource-name-formatter.go
+++ b/instana/resource-name-formatter.go
@@ -4,41 +4,30 @@ import (
 	"strings"
 )
 
-//TerraformManagedResourceNameSuffix the suffix which is appended to a name string
-const TerraformManagedResourceNameSuffix = " (TF managed)"
-
 //ResourceNameFormatter interface for the library to format resource name with a terraform managed string when configured
 type ResourceNameFormatter interface {
 	Format(name string) string
 	UndoFormat(name string) string
 }
 
-//NewResourceNameFormatter creates a new formatter instance depending on if terraform managed string append is requested or not
-func NewResourceNameFormatter(appendString bool) ResourceNameFormatter {
-	if appendString {
-		return &terraformManagedResourceNameFormatter{}
+//NewResourceNameFormatter creates a new formatter instance for the given prefix and suffix
+func NewResourceNameFormatter(prefix string, suffix string) ResourceNameFormatter {
+	return &terraformManagedResourceNameFormatter{
+		prefix: prefix + " ",
+		suffix: " " + suffix,
 	}
-	return &noopResourceNameFormatter{}
-}
-
-//noopResourceNameFormatter implementation of ResourceNameFormatter which is used when no terraform managed string should be appended to the name
-type noopResourceNameFormatter struct{}
-
-func (d *noopResourceNameFormatter) Format(name string) string {
-	return name
-}
-
-func (d *noopResourceNameFormatter) UndoFormat(name string) string {
-	return name
 }
 
 //terraformManagedResourceNameFormatter implementation of ResourceNameFormatter which is used when terraform managed string should be appended to the name
-type terraformManagedResourceNameFormatter struct{}
-
-func (d *terraformManagedResourceNameFormatter) Format(name string) string {
-	return name + TerraformManagedResourceNameSuffix
+type terraformManagedResourceNameFormatter struct {
+	prefix string
+	suffix string
 }
 
-func (d *terraformManagedResourceNameFormatter) UndoFormat(name string) string {
-	return strings.TrimSuffix(name, TerraformManagedResourceNameSuffix)
+func (formatter *terraformManagedResourceNameFormatter) Format(name string) string {
+	return formatter.prefix + name + formatter.suffix
+}
+
+func (formatter *terraformManagedResourceNameFormatter) UndoFormat(name string) string {
+	return strings.TrimPrefix(strings.TrimSuffix(name, formatter.suffix), formatter.prefix)
 }

--- a/instana/resource-name-formatter_test.go
+++ b/instana/resource-name-formatter_test.go
@@ -1,70 +1,58 @@
 package instana_test
 
 import (
-	"reflect"
 	"testing"
 
 	. "github.com/gessnerfl/terraform-provider-instana/instana"
 )
 
-func TestShouldCreateInstanceOfNoopResourceNameFormatterWhenFormattingIsNotActivated(t *testing.T) {
-	inst := NewResourceNameFormatter(false)
+const input = "Test String"
+const prefix = "prefix"
+const suffix = "suffix"
 
-	if instType := reflect.TypeOf(inst).String(); instType != "*instana.noopResourceNameFormatter" {
-		t.Fatalf("Instance should be of type noopResourceNameFormatter but was %s", instType)
-	}
-}
-
-func TestShouldCreateInstanceOfTerraformManagedResourceNameFormatterWhenFormattingIsActivated(t *testing.T) {
-	inst := NewResourceNameFormatter(true)
-
-	if instType := reflect.TypeOf(inst).String(); instType != "*instana.terraformManagedResourceNameFormatter" {
-		t.Fatalf("Instance should be of type terraformManagedResourceNameFormatter but was %s", instType)
-	}
-}
-
-func TestShouldNotAppendSuffixToNameWhenNoopResourceNameFormatterIsUsed(t *testing.T) {
-	input := "Test String"
-	inst := NewResourceNameFormatter(false)
-
-	result := inst.Format(input)
-
-	if input != result {
-		t.Fatalf("Input should not be modified by noopResourceNameFormatter: %s vs %s", input, result)
-	}
-}
-
-func TestShouldNotRemoveSuffixFromNameWhenNoopResourceNameFormatterIsUsed(t *testing.T) {
-	input := "Test String" + TerraformManagedResourceNameSuffix
-	inst := NewResourceNameFormatter(false)
-
-	result := inst.UndoFormat(input)
-
-	if input != result {
-		t.Fatalf("Input should not be modified by noopResourceNameFormatter: %s vs %s", input, result)
-	}
-}
-
-func TestShouldAppendSuffixToNameWhenTerraformManagedResourceNameFormatterIsUsed(t *testing.T) {
-	input := "Test String"
-	expectedResult := input + TerraformManagedResourceNameSuffix
-	inst := NewResourceNameFormatter(true)
+func TestShouldAppendPrefixAndSuffixToName(t *testing.T) {
+	expectedResult := prefix + " " + input + " " + suffix
+	inst := NewResourceNameFormatter(prefix, suffix)
 
 	result := inst.Format(input)
 
 	if expectedResult != result {
-		t.Fatalf("Input string should be appended by terraformManagedResourceNameFormatter when formatting name: %s vs %s", expectedResult, result)
+		t.Fatalf("Prefix and suffix should be appended when formatting name: %s vs %s", expectedResult, result)
 	}
 }
 
 func TestShouldRemoveSuffixFromNameWhenTerraformManagedResourceNameFormatterIsUsed(t *testing.T) {
 	expectedResult := "Test String"
-	input := expectedResult + TerraformManagedResourceNameSuffix
-	inst := NewResourceNameFormatter(true)
+	input := prefix + " " + input + " " + suffix
+	inst := NewResourceNameFormatter(prefix, suffix)
 
 	result := inst.UndoFormat(input)
 
 	if expectedResult != result {
-		t.Fatalf("Suffix string should be trimmed by terraformManagedResourceNameFormatter when undoing format of name: %s vs %s", expectedResult, result)
+		t.Fatalf("Prefix and suffix should be trimmed when undoing format of name: %s vs %s", expectedResult, result)
+	}
+}
+
+func TestShouldNotRemovePrefixStringWhenPrefixStringAppearsInTheMiddle(t *testing.T) {
+	expectedResult := "Test prefix String"
+	input := expectedResult
+	inst := NewResourceNameFormatter(prefix, suffix)
+
+	result := inst.UndoFormat(input)
+
+	if expectedResult != result {
+		t.Fatalf("Prefix should only be trimmed at the beginning: %s vs %s", expectedResult, result)
+	}
+}
+
+func TestShouldNotRemoveSuffixStringWhenSuffixStringAppearsInTheMiddle(t *testing.T) {
+	expectedResult := "Test suffix String"
+	input := expectedResult
+	inst := NewResourceNameFormatter(prefix, suffix)
+
+	result := inst.UndoFormat(input)
+
+	if expectedResult != result {
+		t.Fatalf("Suffix should only be trimmed at the end: %s vs %s", expectedResult, result)
 	}
 }


### PR DESCRIPTION
The configuration is changed to support prefix and suffix configuration.
The old configuration option was removed without migration. Release 0.4.0 will be deleted and should not be used