### PR TITLE
#39 Allow 1024 rule-ids per instana_alerting_config

### DIFF
--- a/instana/resource-alerting-config.go
+++ b/instana/resource-alerting-config.go
@@ -78,7 +78,7 @@ func NewAlertingConfigResourceHandle() *ResourceHandle {
 			AlertingConfigFieldEventFilterRuleIDs: &schema.Schema{
 				Type:     schema.TypeList,
 				MinItems: 0,
-				MaxItems: 6,
+				MaxItems: 1024,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
The Instana-API allows up to 1024 rule-ids per alerting-config.