### PR TITLE
Bugfix/47 fix dynamic built in metrics

### DIFF
--- a/instana/resource-custom-event-specficiation-threshold-rule.go
+++ b/instana/resource-custom-event-specficiation-threshold-rule.go
@@ -43,7 +43,8 @@ var thresholdRuleSchemaFields = map[string]*schema.Schema{
 	},
 	ThresholdRuleFieldMetricName: {
 		Type:        schema.TypeString,
-		Required:    true,
+		Required:    false,
+		Optional:    true,
 		Description: "The metric name of the rule",
 	},
 	ThresholdRuleFieldRollup: {

--- a/instana/resource-custom-event-specficiation-threshold-rule_test.go
+++ b/instana/resource-custom-event-specficiation-threshold-rule_test.go
@@ -89,7 +89,6 @@ resource "instana_custom_event_spec_threshold_rule" "example" {
   description = "description"
   expiration_time = 60000
   rule_severity = "warning"
-  rule_metric_name = "metric_name"
   rule_window = 60000
   rule_aggregation = "sum"
   rule_condition_operator = "=="
@@ -149,12 +148,11 @@ func TestCRUDOfCustomEventSpecificationWithThresholdRuleWithWindowResourceWithMo
 }
 
 func TestCRUDOfCustomEventSpecificationWithThresholdRuleWithMetricPatternResourceWithMockServer(t *testing.T) {
-	ruleAsJson := `{ "ruleType" : "threshold", "severity" : 5, "metricName": "metric_name", "window" : 60000, "aggregation": "sum", "conditionOperator" : "==", "conditionValue" : 1.2, "metricPattern" : { "prefix" : "prefix", "postfix" : "postfix", "placeholder" : "placeholder", "operator" : "startsWith" } }`
+	ruleAsJson := `{ "ruleType" : "threshold", "severity" : 5, "window" : 60000, "aggregation": "sum", "conditionOperator" : "==", "conditionValue" : 1.2, "metricPattern" : { "prefix" : "prefix", "postfix" : "postfix", "placeholder" : "placeholder", "operator" : "startsWith" } }`
 	testCRUDOfResourceCustomEventSpecificationThresholdRuleResourceWithMockServer(
 		t,
 		resourceCustomEventSpecificationWithThresholdRuleAndMetricPatternDefinitionTemplate,
 		ruleAsJson,
-		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, ThresholdRuleFieldMetricName, customEventSpecificationWithThresholdRuleMetricName),
 		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, ThresholdRuleFieldWindow, strconv.FormatInt(customEventSpecificationWithThresholdRuleWindow, 10)),
 		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, ThresholdRuleFieldAggregation, string(customEventSpecificationWithThresholdRuleAggregation)),
 		resource.TestCheckResourceAttr(testCustomEventSpecificationWithThresholdRuleDefinition, ThresholdRuleFieldConditionOperator, string(customEventSpecificationWithThresholdRuleConditionOperator)),
@@ -246,7 +244,7 @@ func TestCustomEventSpecificationWithThresholdRuleSchemaDefinitionIsValid(t *tes
 	schemaAssert.AssertSchemaIsOfTypeBooleanWithDefault(CustomEventSpecificationFieldEnabled, true)
 	schemaAssert.AssertSchemaIsRequiredAndOfTypeString(CustomEventSpecificationRuleSeverity)
 
-	schemaAssert.AssertSchemaIsRequiredAndOfTypeString(ThresholdRuleFieldMetricName)
+	schemaAssert.AssertSchemaIsOptionalAndOfTypeString(ThresholdRuleFieldMetricName)
 	schemaAssert.AssertSchemaIsOptionalAndOfTypeInt(ThresholdRuleFieldWindow)
 	schemaAssert.AssertSchemaIsOptionalAndOfTypeInt(ThresholdRuleFieldRollup)
 	schemaAssert.AssertSchemaIsOptionalAndOfTypeString(ThresholdRuleFieldAggregation)

--- a/instana/restapi/custom-event-specficiations-api.go
+++ b/instana/restapi/custom-event-specficiations-api.go
@@ -267,8 +267,8 @@ func (r *RuleSpecification) validateSystemRule() error {
 }
 
 func (r *RuleSpecification) validateThresholdRule() error {
-	if r.MetricName == nil || len(*r.MetricName) == 0 {
-		return errors.New("metric name of threshold rule is missing")
+	if ((r.MetricName == nil || utils.IsBlank(*r.MetricName)) && r.MetricPattern == nil) || (r.MetricName != nil && !utils.IsBlank(*r.MetricName) && r.MetricPattern != nil) {
+		return errors.New("either metric name or metric pattern of threshold rule needs to be defined")
 	}
 	if (r.Window == nil && r.Rollup == nil) || (r.Window != nil && r.Rollup != nil && *r.Window == 0 && *r.Rollup == 0) {
 		return errors.New("either rollup or window and condition must be defined")

--- a/instana/restapi/custom-event-specficiations-api_test.go
+++ b/instana/restapi/custom-event-specficiations-api_test.go
@@ -33,6 +33,7 @@ const (
 	messagePartExactlyOneRule        = "exactly one rule"
 	messagePartIntegrationId         = "integration id"
 	messagePartConditionOperator     = "condition operator"
+	messagePartMetricNameOrPattern   = "metric name or metric pattern"
 	messagePartMetricPatternPrefix   = "Metric pattern prefix"
 	messagePartMetricPatternOperator = "Metric pattern operator"
 )
@@ -341,7 +342,7 @@ func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameandMetricPa
 	err := rule.Validate()
 
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "metric name")
+	assert.Contains(t, err.Error(), messagePartMetricNameOrPattern)
 }
 
 func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameIsBlankAndMetricPatternIsMissing(t *testing.T) {
@@ -363,7 +364,7 @@ func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameIsBlankAndM
 	err := rule.Validate()
 
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "metric name")
+	assert.Contains(t, err.Error(), messagePartMetricNameOrPattern)
 }
 
 func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameAndMetricPatternAreDefined(t *testing.T) {
@@ -387,7 +388,7 @@ func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameAndMetricPa
 	err := rule.Validate()
 
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "metric name")
+	assert.Contains(t, err.Error(), messagePartMetricNameOrPattern)
 }
 
 func TestShouldFailToValidateThresholdRuleSpecificationWhenNeitherRollupNorWindowIsDefined(t *testing.T) {

--- a/instana/restapi/custom-event-specficiations-api_test.go
+++ b/instana/restapi/custom-event-specficiations-api_test.go
@@ -324,7 +324,7 @@ func TestShouldValidateMinimalThresholdRuleSpecificationWithRollup(t *testing.T)
 	assert.Nil(t, err)
 }
 
-func TestShouldFailToValidateThresholdRuleSpecificationWithWindowWhenMetricNameIsMissing(t *testing.T) {
+func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameandMetricPatternIsMissing(t *testing.T) {
 	conditionOperator := customEventConditionOperator
 	aggregation := customEventAggregation
 	conditionValue := customEventConditionValue
@@ -344,7 +344,7 @@ func TestShouldFailToValidateThresholdRuleSpecificationWithWindowWhenMetricNameI
 	assert.Contains(t, err.Error(), "metric name")
 }
 
-func TestShouldFailToValidateThresholdRuleSpecificationWithWindowWhenMetricNameIsBlank(t *testing.T) {
+func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameIsBlankAndMetricPatternIsMissing(t *testing.T) {
 	metricName := ""
 	conditionOperator := customEventConditionOperator
 	aggregation := customEventAggregation
@@ -358,6 +358,30 @@ func TestShouldFailToValidateThresholdRuleSpecificationWithWindowWhenMetricNameI
 		Aggregation:       &aggregation,
 		ConditionOperator: &conditionOperator,
 		ConditionValue:    &conditionValue,
+	}
+
+	err := rule.Validate()
+
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "metric name")
+}
+
+func TestShouldFailToValidateThresholdRuleSpecificationWhenMetricNameAndMetricPatternAreDefined(t *testing.T) {
+	metricName := "test"
+	conditionOperator := customEventConditionOperator
+	aggregation := customEventAggregation
+	conditionValue := customEventConditionValue
+	window := customEventWindow
+	metricPattern := MetricPattern{Prefix: "test-prefix", Operator: MetricPatternOperatorTypeContains}
+	rule := RuleSpecification{
+		DType:             ThresholdRuleType,
+		Severity:          SeverityWarning.GetAPIRepresentation(),
+		MetricName:        &metricName,
+		Window:            &window,
+		Aggregation:       &aggregation,
+		ConditionOperator: &conditionOperator,
+		ConditionValue:    &conditionValue,
+		MetricPattern:     &metricPattern,
 	}
 
 	err := rule.Validate()
@@ -495,7 +519,6 @@ func TestShouldFailToValidateThresholdRuleSpecificationWithWindowWhenConditionOp
 }
 
 func TestShouldSuccessfullyValidateThresholdRuleSpecificationWithMetricPattern(t *testing.T) {
-	metricName := customEventMetricName
 	aggregation := customEventAggregation
 	conditionOperator := ConditionOperatorEquals
 	conditionValue := customEventConditionValue
@@ -507,7 +530,6 @@ func TestShouldSuccessfullyValidateThresholdRuleSpecificationWithMetricPattern(t
 	rule := RuleSpecification{
 		DType:             ThresholdRuleType,
 		Severity:          SeverityWarning.GetAPIRepresentation(),
-		MetricName:        &metricName,
 		Window:            &window,
 		Aggregation:       &aggregation,
 		ConditionOperator: &conditionOperator,
@@ -521,7 +543,6 @@ func TestShouldSuccessfullyValidateThresholdRuleSpecificationWithMetricPattern(t
 }
 
 func TestShouldFailToValidateThresholdRuleSpecificationWithMetricPatternWhenMetricPatternIsNotValid(t *testing.T) {
-	metricName := customEventMetricName
 	aggregation := customEventAggregation
 	conditionOperator := ConditionOperatorEquals
 	conditionValue := customEventConditionValue
@@ -532,7 +553,6 @@ func TestShouldFailToValidateThresholdRuleSpecificationWithMetricPatternWhenMetr
 	rule := RuleSpecification{
 		DType:             ThresholdRuleType,
 		Severity:          SeverityWarning.GetAPIRepresentation(),
-		MetricName:        &metricName,
 		Window:            &window,
 		Aggregation:       &aggregation,
 		ConditionOperator: &conditionOperator,


### PR DESCRIPTION
fixes clash of metric name and metric prefix in threshold rule. Both are not allowed at the same time. Automated tests and manual test successful