### PR TITLE
Support env vars in provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,9 +60,9 @@ provider "instana" {
 * `api_token` - Required - The API token which is created in the Settings area of Instana for remote access through 
 the REST API. You have to make sure that you assign the proper permissions for this token to configure the desired 
 resources with this provider. E.g. when User Roles should be provisioned by terraform using this provider implementation 
-then the permission 'Access role configuration' must be activated
-* `endpoint` - Required - The endpoint of the instana backend. For SaaS the endpoint URL has the pattern 
-`<tenant>-<organization>.instana.io`. For onPremise installation the endpoint URL depends on your local setup.
+then the permission 'Access role configuration' must be activated. (Defaults to the environment variable `INSTANA_API_TOKEN`).
+* `endpoint` - Required - The endpoint of the instana backend. For SaaS the endpoint URL has the pattern
+`<tenant>-<organization>.instana.io`. For onPremise installation the endpoint URL depends on your local setup. (Defaults to the environment variable `INSTANA_ENDPOINT`).
 * `default_name_prefix` - Optional - string will be added in front the resource UI name or label by default
 (not supported by all resources). For existing resources the string will only be added when the name/label is changed.
 * `default_name_suffix` - `Optional` - Default value " (TF managed)" - string will be appended to the resource UI name or 

--- a/instana/provider.go
+++ b/instana/provider.go
@@ -45,11 +45,13 @@ func providerSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Sensitive:   true,
 			Required:    true,
+			DefaultFunc: schema.EnvDefaultFunc("INSTANA_API_TOKEN", nil),
 			Description: "API token used to authenticate with the Instana Backend",
 		},
 		SchemaFieldEndpoint: {
 			Type:        schema.TypeString,
 			Required:    true,
+			DefaultFunc: schema.EnvDefaultFunc("INSTANA_ENDPOINT", nil),
 			Description: "The DNS Name of the Instana Endpoint (eg. saas-eu-west-1.instana.io)",
 		},
 		SchemaFieldDefaultNamePrefix: {


### PR DESCRIPTION
In CICD pipelines it can be useful to inject certain values such as secrets or endpoints (when using multiple environments). This change allows a user to set an environment variable instead of hard-coding the `api_token` and `endpoint` in the `provider` block.

## How to test

```
export INSTANA_API_TOKEN="<TOKEN>"
export INSTANA_ENDPOINT="<ENDPOINT_URL>"
terraform plan
```

Provider block can be empty when the above two env vars are set:
```
provider "instana" {}
```