### PR TITLE
Missing 'any' custom metric operator

### DIFF
--- a/instana/resource-custom-event-specficiation.go
+++ b/instana/resource-custom-event-specficiation.go
@@ -306,8 +306,8 @@ func NewCustomEventSpecificationResourceHandle() ResourceHandle[*restapi.CustomE
 													CustomEventSpecificationThresholdRuleFieldMetricPatternOperator: {
 														Type:         schema.TypeString,
 														Required:     true,
-														ValidateFunc: validation.StringInSlice([]string{"is", "contains", "startsWith", "endsWith"}, false),
-														Description:  "The metric pattern operator (e.g is, contains, startsWith, endsWith)",
+														ValidateFunc: validation.StringInSlice([]string{"is", "contains", "startsWith", "endsWith", "any"}, false),
+														Description:  "The metric pattern operator (e.g is, contains, startsWith, endsWith, any)",
 													},
 												},
 											},


### PR DESCRIPTION
Adds the missing operator type.

I don't see any unit tests that cover specific checks on operators, so unit testing still passes as expected:
<img width="489" alt="image" src="https://github.com/gessnerfl/terraform-provider-instana/assets/1223869/a7072724-d959-4401-b8fc-16e5a71139e1">
